### PR TITLE
Only log mkcertPath does not exist error when missing

### DIFF
--- a/packages/plugin/src/mkcert/index.ts
+++ b/packages/plugin/src/mkcert/index.ts
@@ -103,11 +103,13 @@ class Mkcert {
     let exist: boolean
     if (this.mkcertLocalPath) {
       exist = await exists(this.mkcertLocalPath)
-      this.logger.error(
-        chalk.red(
-          `${this.mkcertLocalPath} does not exist, please check the mkcertPath paramter`
+      if (!exist) {
+        this.logger.error(
+          chalk.red(
+            `${this.mkcertLocalPath} does not exist, please check the mkcertPath paramter`
+          )
         )
-      )
+      }
     } else {
       exist = await exists(this.mkcertSavedPath)
     }

--- a/packages/plugin/src/mkcert/index.ts
+++ b/packages/plugin/src/mkcert/index.ts
@@ -106,7 +106,7 @@ class Mkcert {
       if (!exist) {
         this.logger.error(
           chalk.red(
-            `${this.mkcertLocalPath} does not exist, please check the mkcertPath paramter`
+            `${this.mkcertLocalPath} does not exist, please check the mkcertPath parameter`
           )
         )
       }


### PR DESCRIPTION
### Description

Currently, the mkcertPath does not exist error is always logged if you provide the mkcertPath option. This corrects that behavior.

### Additional context

None

---

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

