### PR TITLE
feat: use elevated process for mkcert on windows

### DIFF
--- a/packages/plugin/src/lib/util.ts
+++ b/packages/plugin/src/lib/util.ts
@@ -4,6 +4,7 @@ import os from 'os'
 import path from 'path'
 import util from 'util'
 import crypto from 'crypto'
+import process from 'process';
 
 import { PLUGIN_DATA_DIR } from './constant'
 
@@ -59,8 +60,13 @@ export const writeFile = async (
   await fs.promises.chmod(filePath, 0o777)
 }
 
-export const exec = async (cmd: string) => {
-  return await util.promisify(child_process.exec)(cmd)
+export const exec = (cmd: string) => {
+  if (process.platform === "win32") {
+    return util.promisify(child_process.exec)(`Start-Process cmd -Verb RunAs -Wait -ArgumentList '/c cd ${process.cwd()} && ${cmd}'`, {shell: 'powershell.exe'})
+  }
+  else {
+    return util.promisify(child_process.exec)(cmd)
+  }
 }
 
 export const getLocalV4Ips = () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Solves #15 . Uses elevated process to run `mkcert` binary which is required on Windows.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

It's few lines of code I tested outside the package (as I can't use pnpm at the moment, see https://github.com/pnpm/pnpm/issues/3744). Might require testing by someone else. 

By testing outside the package I mean editing compiled code in `node_modules/vite-plugin-mkcert/dist/lib/util.js` (`@1.5.1`) used by my private project.

Result `util.js` around line 72:
```js
const exec = (cmd) => __awaiter(void 0, void 0, void 0, function* () {
    if (process.platform === "win32") {
        return yield util_1.default.promisify(child_process_1.default.exec)(`Start-Process cmd -Verb RunAs -Wait -ArgumentList '/c cd ${process.cwd()} && ${cmd}'`, {shell: 'powershell.exe'})
    }
    else {
        return yield util_1.default.promisify(child_process_1.default.exec)(cmd);
    }
});
```

<details>
Logs with `vite --debug` with fix:

```node
  vite:config bundled config file loaded in 359ms +0ms
  vite:plugin:mkcert The hosts changed from [undefined] to [localhost,192.168.55.6,127.0.0.1], start regenerate certificate +0ms
The certificate is saved in:
C:\Users\PsychoX\.vite-plugin-mkcert\certs\dev.key
C:\Users\PsychoX\.vite-plugin-mkcert\certs\dev.pem
  vite:plugin:mkcert Receive parameter {
  vite:plugin:mkcert   "record": {
  vite:plugin:mkcert     "hosts": [
  vite:plugin:mkcert       "localhost",
  vite:plugin:mkcert       "192.168.55.6",
  vite:plugin:mkcert       "127.0.0.1"
  vite:plugin:mkcert     ],
  vite:plugin:mkcert     "hash": {
  vite:plugin:mkcert       "key": "6167b756c09e0310fd76915b630abe8dbda8fb6815272437fd69ec9d8c311c41",
  vite:plugin:mkcert       "cert": "84edadeafed7cce57c1d4c6ebbf7c2acf70ccb05f945d0ea1d9ffdab4f3d14ad"
  vite:plugin:mkcert     }
  vite:plugin:mkcert   }
  vite:plugin:mkcert }, then update config from {} to {
  vite:plugin:mkcert   "record": {
  vite:plugin:mkcert     "hosts": [
  vite:plugin:mkcert       "localhost",
  vite:plugin:mkcert       "192.168.55.6",
  vite:plugin:mkcert       "127.0.0.1"
  vite:plugin:mkcert     ],
  vite:plugin:mkcert     "hash": {
  vite:plugin:mkcert       "key": "6167b756c09e0310fd76915b630abe8dbda8fb6815272437fd69ec9d8c311c41",
  vite:plugin:mkcert       "cert": "84edadeafed7cce57c1d4c6ebbf7c2acf70ccb05f945d0ea1d9ffdab4f3d14ad"
  vite:plugin:mkcert     }
  vite:plugin:mkcert   }
  vite:plugin:mkcert } +4s
  [...]
```

</details>

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

