### PR TITLE
fix: local path warning only if path isn't found

### DIFF
--- a/plugin/mkcert/index.ts
+++ b/plugin/mkcert/index.ts
@@ -112,11 +112,13 @@ class Mkcert {
     let exist: boolean
     if (this.mkcertLocalPath) {
       exist = await exists(this.mkcertLocalPath)
-      this.logger.error(
-        pc.red(
-          `${this.mkcertLocalPath} does not exist, please check the mkcertPath paramter`
+      if (!exists) {
+        this.logger.error(
+          pc.red(
+            `${this.mkcertLocalPath} does not exist, please check the mkcertPath paramter`
+          )
         )
-      )
+      }
     } else {
       exist = await exists(this.mkcertSavedPath)
     }


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

The `exists` signature catch the error so we need an additional check to prevent warning even if path is found


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

