### PR TITLE
fix: 修复node14不支持replaceAll导致报错的问题

### DIFF
--- a/plugin/mkcert/index.ts
+++ b/plugin/mkcert/index.ts
@@ -165,7 +165,7 @@ class Mkcert {
 
     const commandResult = await exec(commandStatement)
     const caDirPath = path.resolve(
-      commandResult.stdout.toString().replaceAll('\n', '')
+      commandResult.stdout.toString().replace(/\n/g, '')
     )
 
     if (caDirPath === this.savePath) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Node 16以下版本不支持 replaceAll 函数，导致报错。
将 replaceAll 替换成replace + 正则的形式进行修复。
![image](https://user-images.githubusercontent.com/3870098/234439830-a4eb8ade-d94f-4e63-a7d9-69c71de30800.png)
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x ] Bug fix


