### PR TITLE
feat: support MacOS with M2 chip

### DIFF
--- a/plugin/mkcert/source.ts
+++ b/plugin/mkcert/source.ts
@@ -21,7 +21,9 @@ export abstract class BaseSource {
           ? 'linux-arm'
           : 'linux-amd64'
       case 'darwin':
-        return 'darwin-amd64'
+        return process.arch === 'arm64'
+          ? 'darwin-arm64'
+          : 'darwin-amd64'
       default:
         throw new Error('Unsupported platform')
     }


### PR DESCRIPTION
### Description

Make the plugin work on new MacBook pro using a M2 chip that are on an ARM64 architecture

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

