### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import mkcert from'vite-plugin-mkcert'
 export default defineConfig({
   server: {
     https: true
-  },
+  }, // Not needed for Vite 5+ (simply omit this option)
   plugins: [mkcert()]
 })
 ```


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If you have the server.https option set to true, you will get an error, if you bump Vite to version 5+.

See additional context for the error.

### Additional context

```
No overload matches this call.
  The last overload gave the following error.
    Type 'true' has no properties in common with type 'ServerOptions'.ts(2769)
index.d.ts(652, 5): The expected type comes from property 'https' which is declared here on type 'ServerOptions'
index.d.ts(3022, 18): The last overload is declared here.
(property) CommonServerOptions.https?: ServerOptions
Enable TLS + HTTP/2. Note: this downgrades to TLS only when the proxy option is also used.
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

