### PR TITLE
Check for mkcert in PATH if mkcertPath not given, before attempting a download

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-mkcert",
-  "version": "1.17.6",
+  "version": "1.17.7",
   "description": "Provide certificates for vite's https dev service",
   "repository": {
     "type": "git",
@@ -46,7 +46,8 @@
     "@octokit/rest": "^20.1.1",
     "axios": "^1.7.4",
     "debug": "^4.3.6",
-    "picocolors": "^1.0.1"
+    "picocolors": "^1.0.1",
+    "which": "^5.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",

--- a/plugin/mkcert/index.ts
+++ b/plugin/mkcert/index.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import process from 'node:process'
+import which from 'which';
 
 import pc from 'picocolors'
 import type { Logger } from 'vite'
@@ -142,8 +143,16 @@ class Mkcert {
           )
         )
       }
-    } else if (await exists(this.savedMkcert)) {
-      binary = this.savedMkcert
+    } else {
+      /* Check if mkcert in PATH */
+      try {
+        binary = which.sync('mkcert')
+      } catch (err) {
+        /* Not in PATH */
+        if (await exists(this.savedMkcert)) {
+          binary = this.savedMkcert
+        }
+      }
     }
 
     return binary


### PR DESCRIPTION
Big fan of this plugin, a life saver, because certain browser features cannot be used without HTTPS. As someone developing for WebXR, essential for local testing.
<!-- Thank you for contributing! -->

### Description
This PR makes `vite-plugin-mkcert` check for `mkcert` in `PATH`, if `mkcertPath` is not defined, before attempting the default download.

### Additional context
This is to solve two things, which I encountered in an environment with a corporate firewall. `vite-plugin-mkcert` doesn't seem to work with with our proxy and fails the download with `ERCONNRESET`. Downloading manually and specifying `mkcertPath` works, but leads to a code portability problem if the downloaded `mkcert` is not part of the vite-projects's repo and an OS portability issue, if you check in the windows' `mkcert`, but another dev uses linux and vice-versa. Installing `mkcert` to `PATH` and relying on `vite-plugin-mkcert` to check `PATH` was the cleanest solution for me.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

