### PR TITLE
fix: typo in README.md missing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn add vite-plugin-mkcert -D
 
 ```ts
 import {defineConfig} from'vite'
-import mkcert from'vite-plugin-mkcert'
+import mkcert from 'vite-plugin-mkcert'
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
### Description

Includes missing whitespace in snippet at readme instructions

- [x] Documentation update


