### PR TITLE
Avoid shell execution for mkcert hosts

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -48,6 +48,9 @@ let undici = require("undici");
 const exec = async (cmd, options) => {
 	return node_util.default.promisify(node_child_process.default.exec)(cmd, options);
 };
+const execFile = async (file, args = [], options) => {
+	return node_util.default.promisify(node_child_process.default.execFile)(file, args, options);
+};
 const findCommandFromPath = async (command) => {
 	const lookupCmd = node_process.default.platform === "win32" ? `where ${command}` : `command -v ${command}`;
 	try {
@@ -58,9 +61,6 @@ const findCommandFromPath = async (command) => {
 	} catch (_error) {
 		return;
 	}
-};
-const escapeStr = (path) => {
-	return `"${path}"`;
 };
 
 //#endregion
@@ -586,9 +586,11 @@ var Mkcert = class Mkcert {
 	}
 	async retainExistedCA() {
 		if (await this.checkCAExists()) return;
-		const commandStatement = `${escapeStr(await this.getMkcertBinary())} -CAROOT`;
-		debug_log(`Exec ${commandStatement}`);
-		const commandResult = await exec(commandStatement);
+		const mkcertBinary = await this.getMkcertBinary();
+		if (!mkcertBinary) return;
+		const commandArgs = ["-CAROOT"];
+		debug_log(`Exec ${mkcertBinary} ${commandArgs.join(" ")}`);
+		const commandResult = await execFile(mkcertBinary, commandArgs);
 		const caDirPath = node_path.default.resolve(commandResult.stdout.toString().trim());
 		if (caDirPath === this.savePath) return;
 		if (!await exists(caDirPath)) return;
@@ -601,15 +603,21 @@ var Mkcert = class Mkcert {
 		};
 	}
 	async createCertificate(hosts) {
-		const names = hosts.join(" ");
 		const mkcertBinary = await this.getMkcertBinary();
 		if (!mkcertBinary) {
-			error_log(`Mkcert does not exist, unable to generate certificate for ${names}`);
+			error_log(`Mkcert does not exist, unable to generate certificate for ${hosts.join(", ")}`);
 			throw new Error("Mkcert binary is not found");
 		}
 		await ensureDirExist(this.savePath);
 		await this.retainExistedCA();
-		await exec(`${escapeStr(mkcertBinary)} -install -key-file ${escapeStr(this.keyFilePath)} -cert-file ${escapeStr(this.certFilePath)} ${names}`, { env: {
+		await execFile(mkcertBinary, [
+			"-install",
+			"-key-file",
+			this.keyFilePath,
+			"-cert-file",
+			this.certFilePath,
+			...hosts
+		], { env: {
 			...node_process.default.env,
 			CAROOT: this.savePath,
 			JAVA_HOME: void 0

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -12,6 +12,9 @@ import { ProxyAgent, fetch } from "undici";
 const exec = async (cmd, options) => {
 	return util.promisify(child_process.exec)(cmd, options);
 };
+const execFile = async (file, args = [], options) => {
+	return util.promisify(child_process.execFile)(file, args, options);
+};
 const findCommandFromPath = async (command) => {
 	const lookupCmd = process$1.platform === "win32" ? `where ${command}` : `command -v ${command}`;
 	try {
@@ -22,9 +25,6 @@ const findCommandFromPath = async (command) => {
 	} catch (_error) {
 		return;
 	}
-};
-const escapeStr = (path) => {
-	return `"${path}"`;
 };
 
 //#endregion
@@ -550,9 +550,11 @@ var Mkcert = class Mkcert {
 	}
 	async retainExistedCA() {
 		if (await this.checkCAExists()) return;
-		const commandStatement = `${escapeStr(await this.getMkcertBinary())} -CAROOT`;
-		debug_log(`Exec ${commandStatement}`);
-		const commandResult = await exec(commandStatement);
+		const mkcertBinary = await this.getMkcertBinary();
+		if (!mkcertBinary) return;
+		const commandArgs = ["-CAROOT"];
+		debug_log(`Exec ${mkcertBinary} ${commandArgs.join(" ")}`);
+		const commandResult = await execFile(mkcertBinary, commandArgs);
 		const caDirPath = path.resolve(commandResult.stdout.toString().trim());
 		if (caDirPath === this.savePath) return;
 		if (!await exists(caDirPath)) return;
@@ -565,15 +567,21 @@ var Mkcert = class Mkcert {
 		};
 	}
 	async createCertificate(hosts) {
-		const names = hosts.join(" ");
 		const mkcertBinary = await this.getMkcertBinary();
 		if (!mkcertBinary) {
-			error_log(`Mkcert does not exist, unable to generate certificate for ${names}`);
+			error_log(`Mkcert does not exist, unable to generate certificate for ${hosts.join(", ")}`);
 			throw new Error("Mkcert binary is not found");
 		}
 		await ensureDirExist(this.savePath);
 		await this.retainExistedCA();
-		await exec(`${escapeStr(mkcertBinary)} -install -key-file ${escapeStr(this.keyFilePath)} -cert-file ${escapeStr(this.certFilePath)} ${names}`, { env: {
+		await execFile(mkcertBinary, [
+			"-install",
+			"-key-file",
+			this.keyFilePath,
+			"-cert-file",
+			this.certFilePath,
+			...hosts
+		], { env: {
 			...process$1.env,
 			CAROOT: this.savePath,
 			JAVA_HOME: void 0

--- a/plugin/src/mkcert/index.ts
+++ b/plugin/src/mkcert/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import process from 'node:process'
-import { escapeStr, exec, findCommandFromPath } from '../utils/command'
+import { execFile, findCommandFromPath } from '../utils/command'
 import { PLUGIN_DATA_DIR } from '../utils/constant'
 import {
   copyDir,
@@ -166,11 +166,14 @@ class Mkcert {
     }
 
     const mkcertBinary = await this.getMkcertBinary()
-    const commandStatement = `${escapeStr(mkcertBinary)} -CAROOT`
+    if (!mkcertBinary) {
+      return
+    }
+    const commandArgs = ['-CAROOT']
 
-    debug_log(`Exec ${commandStatement}`)
+    debug_log(`Exec ${mkcertBinary} ${commandArgs.join(' ')}`)
 
-    const commandResult = await exec(commandStatement)
+    const commandResult = await execFile(mkcertBinary, commandArgs)
     const caDirPath = path.resolve(commandResult.stdout.toString().trim())
 
     if (caDirPath === this.savePath) {
@@ -197,12 +200,11 @@ class Mkcert {
   }
 
   private async createCertificate(hosts: string[]) {
-    const names = hosts.join(' ')
     const mkcertBinary = await this.getMkcertBinary()
 
     if (!mkcertBinary) {
       error_log(
-        `Mkcert does not exist, unable to generate certificate for ${names}`
+        `Mkcert does not exist, unable to generate certificate for ${hosts.join(', ')}`
       )
       throw new Error('Mkcert binary is not found')
     }
@@ -210,11 +212,16 @@ class Mkcert {
     await ensureDirExist(this.savePath)
     await this.retainExistedCA()
 
-    const cmd = `${escapeStr(mkcertBinary)} -install -key-file ${escapeStr(
-      this.keyFilePath
-    )} -cert-file ${escapeStr(this.certFilePath)} ${names}`
+    const commandArgs = [
+      '-install',
+      '-key-file',
+      this.keyFilePath,
+      '-cert-file',
+      this.certFilePath,
+      ...hosts
+    ]
 
-    await exec(cmd, {
+    await execFile(mkcertBinary, commandArgs, {
       env: {
         ...process.env,
         CAROOT: this.savePath,

--- a/plugin/src/utils/command.ts
+++ b/plugin/src/utils/command.ts
@@ -1,9 +1,20 @@
-import child_process, { type ExecOptions } from 'node:child_process'
+import child_process, {
+  type ExecFileOptions,
+  type ExecOptions
+} from 'node:child_process'
 import process from 'node:process'
 import util from 'node:util'
 
 export const exec = async (cmd: string, options?: ExecOptions) => {
   return util.promisify(child_process.exec)(cmd, options)
+}
+
+export const execFile = async (
+  file: string,
+  args: string[] = [],
+  options?: ExecFileOptions
+) => {
+  return util.promisify(child_process.execFile)(file, args, options)
 }
 
 export const findCommandFromPath = async (command: string) => {
@@ -23,8 +34,4 @@ export const findCommandFromPath = async (command: string) => {
   } catch (_error) {
     return undefined
   }
-}
-
-export const escapeStr = (path?: string) => {
-  return `"${path}"`
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR hardens `vite-plugin-mkcert` by removing shell-based command construction when invoking `mkcert`.

Previously, host values were joined into a single shell command string before execution. That meant values from `hosts` could be interpreted by the shell instead of being treated purely as command arguments. This PR changes those `mkcert` invocations to use argument arrays via `execFile`, so host entries are passed as data rather than shell syntax.

The change also updates the existing `-CAROOT` lookup path to use argument-based execution for consistency and safety.

### Additional context

This is intended as a hardening change. Behavior for valid host values should remain the same, but invalid or maliciously crafted host input will no longer be interpreted by the shell.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

