### PR TITLE
build(plugin): update undici to ^8.5.0 to fix security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "debug": "^4.4.3",
     "supports-color": "^10.2.2",
-    "undici": "^8.3.0"
+    "undici": "^8.5.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^10.2.2
         version: 10.2.2
       undici:
-        specifier: ^8.3.0
-        version: 8.3.0
+        specifier: ^8.5.0
+        version: 8.5.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.16
@@ -1701,8 +1701,8 @@ packages:
     resolution: {integrity: sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==}
     engines: {node: '>=20.18.1'}
 
-  undici@8.3.0:
-    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
     engines: {node: '>=22.19.0'}
 
   unicode-emoji-modifier-base@1.0.0:
@@ -3317,7 +3317,7 @@ snapshots:
 
   undici@7.27.0: {}
 
-  undici@8.3.0: {}
+  undici@8.5.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 


### PR DESCRIPTION
Bump undici from ^8.3.0 to ^8.5.0 to pull in the security fixes shipped in the 8.4.x and 8.5.0 releases. The plugin uses undici's fetch and ProxyAgent in plugin/src/utils/request.ts for (proxied) mkcert binary downloads, so these advisories apply directly.

Notable advisories addressed (patched in undici 8.5.0):
- CVE-2026-9697 (High): SOCKS5 ProxyAgent dropped the requestTls option, bypassing TLS certificate validation and exposing proxied downloads to man-in-the-middle attacks. https://github.com/nodejs/undici/security/advisories/GHSA-vmh5-mc38-953g
- CVE-2026-12151: WebSocket continuation-frame flood causing unbounded memory growth (DoS). https://github.com/nodejs/undici/security/advisories/GHSA-vxpw-j846-p89q
- CVE-2026-9675: WebSocket fragmentation payload-size-limit bypass. https://github.com/nodejs/undici/security/advisories/GHSA-38rv-x7px-6hhq
- CVE-2026-9678: cache interceptor directive whitespace mishandling. https://github.com/nodejs/undici/security/advisories/GHSA-pr7r-676h-xcf6
- CVE-2026-9679: cookie parser percent-decoding header injection. https://github.com/nodejs/undici/security/advisories/GHSA-p88m-4jfj-68fv


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ X] Other

